### PR TITLE
Домашнее задание

### DIFF
--- a/hw-06-jpql/.gitignore
+++ b/hw-06-jpql/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/hw-06-jpql/pom.xml
+++ b/hw-06-jpql/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.3.4.RELEASE</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>ru.otus</groupId>
+	<artifactId>hw-06-jpql</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>hw-06-jpql</name>
+	<description>Demo project for Spring Boot</description>
+
+	<properties>
+		<java.version>11</java.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.shell</groupId>
+			<artifactId>spring-shell-starter</artifactId>
+			<version>2.0.1.RELEASE</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>1.4.200</version>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.junit.vintage</groupId>
+					<artifactId>junit-vintage-engine</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/Application.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/Application.java
@@ -1,0 +1,11 @@
+package ru.otus.hw06jpql;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Author.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Author.java
@@ -1,0 +1,30 @@
+package ru.otus.hw06jpql.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@Entity
+@Table(name = "author")
+@AllArgsConstructor
+@NoArgsConstructor
+public class Author {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "surname", nullable = false)
+    private String surname;
+
+    @Override
+    public String toString() {
+        return name + " " + surname;
+    }
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Book.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Book.java
@@ -31,9 +31,6 @@ public class Book {
     @OneToOne(targetEntity = Genre.class, cascade = CascadeType.ALL)
     private Genre genre;
 
-    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Comment> comments;
-
     @Override
     public String toString() {
         return "id=" + id + " " + name + " " + author + " " + genre;

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Book.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Book.java
@@ -1,0 +1,41 @@
+package ru.otus.hw06jpql.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Data
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "book")
+@NamedEntityGraph(name = "book-entity-graph",
+        attributeNodes = {@NamedAttributeNode("author"), @NamedAttributeNode("genre")})
+public class Book {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @JoinColumn(name = "author_id")
+    @OneToOne(targetEntity = Author.class, cascade = CascadeType.ALL)
+    private Author author;
+
+    @JoinColumn(name = "genre_id")
+    @OneToOne(targetEntity = Genre.class, cascade = CascadeType.ALL)
+    private Genre genre;
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Comment> comments;
+
+    @Override
+    public String toString() {
+        return "id=" + id + " " + name + " " + author + " " + genre;
+    }
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Book.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Book.java
@@ -31,6 +31,9 @@ public class Book {
     @OneToOne(targetEntity = Genre.class, cascade = CascadeType.ALL)
     private Genre genre;
 
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Comment> comments;
+
     @Override
     public String toString() {
         return "id=" + id + " " + name + " " + author + " " + genre;

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Comment.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Comment.java
@@ -1,0 +1,26 @@
+package ru.otus.hw06jpql.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@Entity
+@Table(name = "comment")
+@AllArgsConstructor
+@NoArgsConstructor
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(name = "text", nullable = false)
+    private String text;
+
+    @ManyToOne
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Genre.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/domain/Genre.java
@@ -1,0 +1,27 @@
+package ru.otus.hw06jpql.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Data
+@Entity
+@Table(name = "genre")
+@AllArgsConstructor
+@NoArgsConstructor
+public class Genre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/AuthorRepository.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/AuthorRepository.java
@@ -1,0 +1,13 @@
+package ru.otus.hw06jpql.repository;
+
+
+import ru.otus.hw06jpql.domain.Author;
+
+import java.util.Optional;
+
+public interface AuthorRepository {
+
+    Author insertOrUpdate(Author author);
+
+    Optional<Author> getById(long id);
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/AuthorRepositoryJpa.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/AuthorRepositoryJpa.java
@@ -1,0 +1,30 @@
+package ru.otus.hw06jpql.repository;
+
+import org.springframework.stereotype.Repository;
+import ru.otus.hw06jpql.domain.Author;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.Optional;
+
+@Repository
+public class AuthorRepositoryJpa implements AuthorRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Author insertOrUpdate(Author author) {
+        if (author.getId() <= 0) {
+            em.persist(author);
+            return author;
+        } else {
+            return em.merge(author);
+        }
+    }
+
+    @Override
+    public Optional<Author> getById(long id) {
+        return Optional.ofNullable(em.find(Author.class, id));
+    }
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/BookRepository.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/BookRepository.java
@@ -1,0 +1,18 @@
+package ru.otus.hw06jpql.repository;
+
+
+import ru.otus.hw06jpql.domain.Book;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BookRepository {
+
+    List<Book> getAll();
+
+    Optional<Book> getById(long id);
+
+    Book insertOrUpdate(Book book);
+
+    void remove(long id);
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/BookRepositoryJpa.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/BookRepositoryJpa.java
@@ -1,0 +1,48 @@
+package ru.otus.hw06jpql.repository;
+
+import org.springframework.stereotype.Repository;
+import ru.otus.hw06jpql.domain.Book;
+
+import javax.persistence.*;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class BookRepositoryJpa implements BookRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public List<Book> getAll() {
+        EntityGraph<?> entityGraph = em.getEntityGraph("book-entity-graph");
+        TypedQuery<Book> query = em.createQuery("select b from Book b join fetch b.comments", Book.class);
+        query.setHint("javax.persistence.fetchgraph", entityGraph);
+        return query.getResultList();
+    }
+
+    @Override
+    public Optional<Book> getById(long id) {
+        return Optional.ofNullable(em.find(Book.class, id));
+    }
+
+    @Override
+    public Book insertOrUpdate(Book book) {
+        if (book.getId() <= 0) {
+            em.persist(book);
+            return book;
+        } else {
+            return em.merge(book);
+        }
+    }
+
+    @Override
+    public void remove(long id) {
+        Query query = em.createQuery("delete " +
+                "from Book b " +
+                "where b.id = :id");
+        query.setParameter("id", id);
+        query.executeUpdate();
+    }
+
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/BookRepositoryJpa.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/BookRepositoryJpa.java
@@ -16,7 +16,7 @@ public class BookRepositoryJpa implements BookRepository {
     @Override
     public List<Book> getAll() {
         EntityGraph<?> entityGraph = em.getEntityGraph("book-entity-graph");
-        TypedQuery<Book> query = em.createQuery("select b from Book b join fetch b.comments", Book.class);
+        TypedQuery<Book> query = em.createQuery("select b from Book b", Book.class);
         query.setHint("javax.persistence.fetchgraph", entityGraph);
         return query.getResultList();
     }

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepository.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepository.java
@@ -1,0 +1,15 @@
+package ru.otus.hw06jpql.repository;
+
+import ru.otus.hw06jpql.domain.Comment;
+
+import java.util.Optional;
+
+public interface CommentRepository {
+
+    Comment insertOrUpdate(Comment comment);
+
+    Optional<Comment> getById(long id);
+
+    void remove(long id);
+
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepository.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package ru.otus.hw06jpql.repository;
 
 import ru.otus.hw06jpql.domain.Comment;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository {
@@ -9,6 +10,8 @@ public interface CommentRepository {
     Comment insertOrUpdate(Comment comment);
 
     Optional<Comment> getById(long id);
+
+    List<Comment> getCommentsByBookId(long id);
 
     void remove(long id);
 

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepository.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepository.java
@@ -2,7 +2,6 @@ package ru.otus.hw06jpql.repository;
 
 import ru.otus.hw06jpql.domain.Comment;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface CommentRepository {
@@ -10,8 +9,6 @@ public interface CommentRepository {
     Comment insertOrUpdate(Comment comment);
 
     Optional<Comment> getById(long id);
-
-    List<Comment> getCommentsByBookId(long id);
 
     void remove(long id);
 

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepositoryJpa.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepositoryJpa.java
@@ -1,0 +1,40 @@
+package ru.otus.hw06jpql.repository;
+
+import org.springframework.stereotype.Repository;
+import ru.otus.hw06jpql.domain.Comment;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import java.util.Optional;
+
+@Repository
+public class CommentRepositoryJpa implements CommentRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Comment insertOrUpdate(Comment comment) {
+        if (comment.getId() <= 0) {
+            em.persist(comment);
+            return comment;
+        } else {
+            return em.merge(comment);
+        }
+    }
+
+    @Override
+    public Optional<Comment> getById(long id) {
+        return Optional.ofNullable(em.find(Comment.class, id));
+    }
+
+    @Override
+    public void remove(long id) {
+        Query query = em.createQuery("delete " +
+                "from Comment c " +
+                "where c.id = :id");
+        query.setParameter("id", id);
+        query.executeUpdate();
+    }
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepositoryJpa.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepositoryJpa.java
@@ -6,6 +6,8 @@ import ru.otus.hw06jpql.domain.Comment;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -27,6 +29,16 @@ public class CommentRepositoryJpa implements CommentRepository {
     @Override
     public Optional<Comment> getById(long id) {
         return Optional.ofNullable(em.find(Comment.class, id));
+    }
+
+    @Override
+    public List<Comment> getCommentsByBookId(long id){
+        TypedQuery<Comment> query = em.createQuery("select c " +
+                        "from Comment c " +
+                        "where c.book.id = :id",
+                Comment.class);
+        query.setParameter("id", id);
+        return query.getResultList();
     }
 
     @Override

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepositoryJpa.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/CommentRepositoryJpa.java
@@ -6,8 +6,6 @@ import ru.otus.hw06jpql.domain.Comment;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.Query;
-import javax.persistence.TypedQuery;
-import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -29,16 +27,6 @@ public class CommentRepositoryJpa implements CommentRepository {
     @Override
     public Optional<Comment> getById(long id) {
         return Optional.ofNullable(em.find(Comment.class, id));
-    }
-
-    @Override
-    public List<Comment> getCommentsByBookId(long id){
-        TypedQuery<Comment> query = em.createQuery("select c " +
-                        "from Comment c " +
-                        "where c.book.id = :id",
-                Comment.class);
-        query.setParameter("id", id);
-        return query.getResultList();
     }
 
     @Override

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/GenreRepository.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/GenreRepository.java
@@ -1,0 +1,13 @@
+package ru.otus.hw06jpql.repository;
+
+
+import ru.otus.hw06jpql.domain.Genre;
+
+import java.util.Optional;
+
+public interface GenreRepository {
+
+    Genre insertOrUpdate(Genre genre);
+
+    Optional<Genre> getById(long id);
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/GenreRepositoryJpa.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/repository/GenreRepositoryJpa.java
@@ -1,0 +1,30 @@
+package ru.otus.hw06jpql.repository;
+
+import org.springframework.stereotype.Repository;
+import ru.otus.hw06jpql.domain.Genre;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.Optional;
+
+@Repository
+public class GenreRepositoryJpa implements GenreRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Override
+    public Genre insertOrUpdate(Genre genre) {
+        if (genre.getId() <= 0) {
+            em.persist(genre);
+            return genre;
+        } else {
+            return em.merge(genre);
+        }
+    }
+
+    @Override
+    public Optional<Genre> getById(long id) {
+        return Optional.ofNullable(em.find(Genre.class, id));
+    }
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/AuthorShell.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/AuthorShell.java
@@ -1,0 +1,40 @@
+package ru.otus.hw06jpql.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
+import org.springframework.transaction.annotation.Transactional;
+import ru.otus.hw06jpql.repository.AuthorRepository;
+import ru.otus.hw06jpql.domain.Author;
+
+import java.util.Optional;
+
+@ShellComponent
+@RequiredArgsConstructor
+public class AuthorShell {
+
+    private final AuthorRepository authorRepository;
+
+    @Transactional
+    @ShellMethod(key = "author", value = "Введите id, имя и фамилию (Например: author 1 Иванов Иван )")
+    public String createAuthor(@ShellOption({"authorId", "id"}) long id,
+                               @ShellOption({"authorName", "an"}) String name,
+                               @ShellOption({"authorSurname", "us"}) String surname) {
+        Author author = new Author(id, name, surname);
+        authorRepository.insertOrUpdate(author);
+        return "Автор " + author.toString() + " зарегистрирован в системе!";
+    }
+
+    @Transactional(readOnly = true)
+    @ShellMethod(key = "authorById", value = "Введите id (Например: authorById 1)")
+    public String getById(@ShellOption({"authorId", "id"}) long id) {
+        Optional<Author> author = authorRepository.getById(id);
+        if (author.isPresent()) {
+            return author.toString();
+        } else {
+            return "Автор не найден!";
+        }
+    }
+
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/BookShell.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/BookShell.java
@@ -6,6 +6,7 @@ import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.standard.ShellOption;
 import org.springframework.transaction.annotation.Transactional;
+import ru.otus.hw06jpql.domain.Comment;
 import ru.otus.hw06jpql.repository.AuthorRepository;
 import ru.otus.hw06jpql.repository.BookRepository;
 import ru.otus.hw06jpql.repository.GenreRepository;
@@ -13,6 +14,8 @@ import ru.otus.hw06jpql.domain.Author;
 import ru.otus.hw06jpql.domain.Book;
 import ru.otus.hw06jpql.domain.Genre;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -41,7 +44,7 @@ public class BookShell {
         if (genre == null) {
             return "Жанр c id = " + genreId + " не зарегистрирован в системе!";
         }
-        Book book = new Book(id, name, author, genre);
+        Book book = new Book(id, name, author, genre, Collections.emptyList());
         bookRepository.insertOrUpdate(book);
         return "Книга " + book.toString() + " зарегистрирована в системе!";
     }
@@ -70,6 +73,11 @@ public class BookShell {
     public String removeById(@ShellOption({"bookId", "id"}) long id) {
         bookRepository.remove(id);
         return "Книга с id = " + id + " удалена!";
+    }
+
+    @Transactional(readOnly = true)
+    public List<Comment> getCommentsByBook(Book book) {
+        return book.getComments();
     }
 
     private Genre getGenre(long genreId) {

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/BookShell.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/BookShell.java
@@ -13,7 +13,6 @@ import ru.otus.hw06jpql.domain.Author;
 import ru.otus.hw06jpql.domain.Book;
 import ru.otus.hw06jpql.domain.Genre;
 
-import java.util.ArrayList;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -42,7 +41,7 @@ public class BookShell {
         if (genre == null) {
             return "Жанр c id = " + genreId + " не зарегистрирован в системе!";
         }
-        Book book = new Book(id, name, author, genre, new ArrayList<>());
+        Book book = new Book(id, name, author, genre);
         bookRepository.insertOrUpdate(book);
         return "Книга " + book.toString() + " зарегистрирована в системе!";
     }

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/BookShell.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/BookShell.java
@@ -1,0 +1,84 @@
+package ru.otus.hw06jpql.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
+import org.springframework.transaction.annotation.Transactional;
+import ru.otus.hw06jpql.repository.AuthorRepository;
+import ru.otus.hw06jpql.repository.BookRepository;
+import ru.otus.hw06jpql.repository.GenreRepository;
+import ru.otus.hw06jpql.domain.Author;
+import ru.otus.hw06jpql.domain.Book;
+import ru.otus.hw06jpql.domain.Genre;
+
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Log
+@ShellComponent
+@RequiredArgsConstructor
+public class BookShell {
+
+    private final BookRepository bookRepository;
+
+    private final AuthorRepository authorRepository;
+
+    private final GenreRepository genreRepository;
+
+    @Transactional
+    @ShellMethod(key = "book", value = "Введите id, название, id автора,id жанра (Например: book 1 имя 1 1)")
+    public String createAuthor(@ShellOption({"bookId", "id"}) long id,
+                               @ShellOption({"bookName", "bn"}) String name,
+                               @ShellOption({"authorId", "ai"}) long authorId,
+                               @ShellOption({"genreId", "di"}) long genreId) {
+        Author author = getAuthor(authorId);
+        if (author == null) {
+            return "Автор c id = " + authorId + " не зарегистрирован в системе!";
+        }
+        Genre genre = getGenre(genreId);
+        if (genre == null) {
+            return "Жанр c id = " + genreId + " не зарегистрирован в системе!";
+        }
+        Book book = new Book(id, name, author, genre, new ArrayList<>());
+        bookRepository.insertOrUpdate(book);
+        return "Книга " + book.toString() + " зарегистрирована в системе!";
+    }
+
+    @Transactional(readOnly = true)
+    @ShellMethod(key = "bookById", value = "Введите id (Например: bookById 1)")
+    public String getById(@ShellOption({"bookById", "id"}) long id) {
+        Optional<Book> book = bookRepository.getById(id);
+        if (book.isPresent()) {
+            return book.get().toString();
+        } else {
+            return "Книга не найдена!";
+        }
+    }
+
+    @Transactional(readOnly = true)
+    @ShellMethod(key = "getAllBook", value = "Вывод всех книг")
+    public String getAll() {
+        return bookRepository.getAll().stream()
+                .map(Book::toString)
+                .collect(Collectors.joining("\n", "", ""));
+    }
+
+    @Transactional
+    @ShellMethod(key = "removeBookById", value = "Введите id (Например: removeBookById 1)")
+    public String removeById(@ShellOption({"bookId", "id"}) long id) {
+        bookRepository.remove(id);
+        return "Книга с id = " + id + " удалена!";
+    }
+
+    private Genre getGenre(long genreId) {
+        return genreRepository.getById(genreId).orElse(null);
+    }
+
+    private Author getAuthor(long id) {
+        return authorRepository.getById(id).orElse(null);
+    }
+
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/CommentShell.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/CommentShell.java
@@ -9,9 +9,7 @@ import ru.otus.hw06jpql.domain.Comment;
 import ru.otus.hw06jpql.repository.BookRepositoryJpa;
 import ru.otus.hw06jpql.repository.CommentRepositoryJpa;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @ShellComponent
 @RequiredArgsConstructor
@@ -41,15 +39,6 @@ public class CommentShell {
         } else {
             return "Комментарий не найден!";
         }
-    }
-
-    @Transactional(readOnly = true)
-    @ShellMethod(key = "commentsBookIdById", value = "Введите id (Например: commentsBookIdById 1)")
-    public String getCommentsByBookId(@ShellOption({"bookId", "id"}) long id) {
-        List<Comment> comments = commentRepositoryJpa.getCommentsByBookId(id);
-        return comments.stream()
-                .map(Comment::toString)
-                .collect(Collectors.joining("\n", "", ""));
     }
 
     @Transactional

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/CommentShell.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/CommentShell.java
@@ -1,0 +1,50 @@
+package ru.otus.hw06jpql.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
+import org.springframework.transaction.annotation.Transactional;
+import ru.otus.hw06jpql.domain.Comment;
+import ru.otus.hw06jpql.repository.BookRepositoryJpa;
+import ru.otus.hw06jpql.repository.CommentRepositoryJpa;
+
+import java.util.Optional;
+
+@ShellComponent
+@RequiredArgsConstructor
+public class CommentShell {
+
+    private final CommentRepositoryJpa commentRepositoryJpa;
+
+    private final BookRepositoryJpa bookRepositoryJpa;
+
+    @Transactional
+    @ShellMethod(key = "comment", value = "Введите id книги и комментарий (Например: comment 1 фывыф)")
+    public String createComment(@ShellOption({"bookId", "bi"}) long bookId,
+                                @ShellOption({"text", "t"}) String text) {
+        Comment comment = new Comment();
+        comment.setText(text);
+        bookRepositoryJpa.getById(bookId).ifPresent(comment::setBook);
+        commentRepositoryJpa.insertOrUpdate(comment);
+        return "Комментарий " + comment.toString() + " зарегистрирован в системе!";
+    }
+
+    @Transactional(readOnly = true)
+    @ShellMethod(key = "commentById", value = "Введите id (Например: commentById 1)")
+    public String getById(@ShellOption({"commentId", "id"}) long id) {
+        Optional<Comment> comment = commentRepositoryJpa.getById(id);
+        if (comment.isPresent()) {
+            return comment.toString();
+        } else {
+            return "Комментарий не найден!";
+        }
+    }
+
+    @Transactional
+    @ShellMethod(key = "removeCommentById", value = "Введите id (Например: removeCommentById 1)")
+    public String removeById(@ShellOption({"commentId", "id"}) long id) {
+        commentRepositoryJpa.remove(id);
+        return "Комментарий с id = " + id + " удален!";
+    }
+}

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/CommentShell.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/CommentShell.java
@@ -9,7 +9,9 @@ import ru.otus.hw06jpql.domain.Comment;
 import ru.otus.hw06jpql.repository.BookRepositoryJpa;
 import ru.otus.hw06jpql.repository.CommentRepositoryJpa;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @ShellComponent
 @RequiredArgsConstructor
@@ -39,6 +41,15 @@ public class CommentShell {
         } else {
             return "Комментарий не найден!";
         }
+    }
+
+    @Transactional(readOnly = true)
+    @ShellMethod(key = "commentsBookIdById", value = "Введите id (Например: commentsBookIdById 1)")
+    public String getCommentsByBookId(@ShellOption({"bookId", "id"}) long id) {
+        List<Comment> comments = commentRepositoryJpa.getCommentsByBookId(id);
+        return comments.stream()
+                .map(Comment::toString)
+                .collect(Collectors.joining("\n", "", ""));
     }
 
     @Transactional

--- a/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/GenreShell.java
+++ b/hw-06-jpql/src/main/java/ru/otus/hw06jpql/service/GenreShell.java
@@ -1,0 +1,39 @@
+package ru.otus.hw06jpql.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
+import org.springframework.transaction.annotation.Transactional;
+import ru.otus.hw06jpql.repository.GenreRepository;
+import ru.otus.hw06jpql.domain.Genre;
+
+import java.util.Optional;
+
+@ShellComponent
+@RequiredArgsConstructor
+public class GenreShell {
+
+    private final GenreRepository genreRepository;
+
+    @Transactional
+    @ShellMethod(key = "genre", value = "Введите id, название жанра (Например: genre 1 Роман)")
+    public String createGenre(@ShellOption({"genreId", "id"}) long id,
+                              @ShellOption({"genreName", "gn"}) String name) {
+        Genre genre = new Genre(id, name);
+        genreRepository.insertOrUpdate(genre);
+        return "Жанр " + genre.toString() + " зарегистрирован в системе!";
+    }
+
+    @Transactional(readOnly = true)
+    @ShellMethod(key = "genreById", value = "Введите id (Например: 1 Роман)")
+    public String getById(@ShellOption({"genreId", "id"}) long id) {
+        Optional<Genre> genre = genreRepository.getById(id);
+        if (genre.isPresent()) {
+            return genre.get().toString();
+        } else {
+            return "Жанр с таким id не найден!";
+        }
+    }
+
+}

--- a/hw-06-jpql/src/main/resources/application.yml
+++ b/hw-06-jpql/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    initialization-mode: always
+    schema: schema.sql
+
+  jpa:
+    generate-ddl: false
+    hibernate:
+      ddl-auto:  none
+    show-sql: false
+
+logging:
+  level:
+    ROOT: ERROR

--- a/hw-06-jpql/src/main/resources/schema.sql
+++ b/hw-06-jpql/src/main/resources/schema.sql
@@ -1,0 +1,27 @@
+create table genre(
+    id bigserial,
+    name varchar(255),
+    primary key (id)
+);
+
+create table author(
+    id bigserial,
+    name varchar(255),
+    surname varchar(255),
+    primary key (id)
+);
+
+create table book(
+    id bigserial,
+    name varchar(255),
+    author_id bigint references author (id),
+    genre_id bigint references genre (id),
+    primary key (id)
+);
+
+create table comment(
+    id bigserial,
+    text varchar(8000),
+    book_id bigint references book(id) on delete cascade,
+    primary key (id)
+);

--- a/hw-06-jpql/src/test/java/ru/otus/hw06jpql/Hw06JpqlApplicationTests.java
+++ b/hw-06-jpql/src/test/java/ru/otus/hw06jpql/Hw06JpqlApplicationTests.java
@@ -1,0 +1,13 @@
+package ru.otus.hw06jpql;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class Hw06JpqlApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/AuthorRepositoryJpaTest.java
+++ b/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/AuthorRepositoryJpaTest.java
@@ -1,0 +1,45 @@
+package ru.otus.hw06jpql.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import ru.otus.hw06jpql.domain.Author;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(AuthorRepositoryJpa.class)
+class AuthorRepositoryJpaTest {
+
+    @Autowired
+    private AuthorRepositoryJpa authorRepositoryJpa;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void insert() {
+        Author author = new Author();
+        author.setName("name");
+        author.setSurname("surname");
+        Author newAuthor = authorRepositoryJpa.insertOrUpdate(author);
+        Author expectedAuthor = em.find(Author.class, newAuthor.getId());
+        Assertions.assertThat(expectedAuthor).isNotNull()
+                .matches(a -> a.getId() == newAuthor.getId())
+                .matches(a -> a.getName().equals(newAuthor.getName()))
+                .matches(a -> a.getSurname().equals(newAuthor.getSurname()));
+    }
+
+    @Test
+    void getById() {
+        Optional<Author> optionalActualAuthor = authorRepositoryJpa.getById(1L);
+        Author expectedAuthor = em.find(Author.class, 1L);
+        assertThat(optionalActualAuthor).isPresent().get()
+                .isEqualToComparingFieldByField(expectedAuthor);
+    }
+}

--- a/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/BookRepositoryJpaTest.java
+++ b/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/BookRepositoryJpaTest.java
@@ -9,10 +9,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import ru.otus.hw06jpql.domain.Author;
 import ru.otus.hw06jpql.domain.Book;
-import ru.otus.hw06jpql.domain.Comment;
 import ru.otus.hw06jpql.domain.Genre;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -62,18 +60,13 @@ class BookRepositoryJpaTest {
         book.setAuthor(author);
         book.setGenre(genre);
 
-        Comment comment = new Comment();
-        comment.setText("good");
-        book.setComments(Collections.singletonList(comment));
-
         Book newBook = bookRepositoryJpa.insertOrUpdate(book);
         Book expectedBook = em.find(Book.class, newBook.getId());
         Assertions.assertThat(expectedBook).isNotNull()
                 .matches(b -> b.getId() == newBook.getId())
                 .matches(b -> b.getName().equals(newBook.getName()))
                 .matches(b -> b.getAuthor().equals(newBook.getAuthor()))
-                .matches(b -> b.getGenre().equals(newBook.getGenre()))
-                .matches(b -> b.getComments() != null && b.getComments().size() > 0 );
+                .matches(b -> b.getGenre().equals(newBook.getGenre()));
     }
 
     @Test

--- a/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/BookRepositoryJpaTest.java
+++ b/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/BookRepositoryJpaTest.java
@@ -1,0 +1,90 @@
+package ru.otus.hw06jpql.repository;
+
+import org.assertj.core.api.Assertions;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import ru.otus.hw06jpql.domain.Author;
+import ru.otus.hw06jpql.domain.Book;
+import ru.otus.hw06jpql.domain.Comment;
+import ru.otus.hw06jpql.domain.Genre;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({BookRepositoryJpa.class})
+class BookRepositoryJpaTest {
+
+    @Autowired
+    private BookRepositoryJpa bookRepositoryJpa;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void getAll() {
+        SessionFactory sessionFactory = em.getEntityManager().getEntityManagerFactory()
+                .unwrap(SessionFactory.class);
+        sessionFactory.getStatistics().setStatisticsEnabled(true);
+        List<Book> books = bookRepositoryJpa.getAll();
+        assertThat(books).isNotNull().hasSize(2)
+                .allMatch(s -> !s.getName().equals(""))
+                .allMatch(s -> s.getGenre() != null)
+                .allMatch(s -> s.getAuthor() != null);
+        assertThat(sessionFactory.getStatistics().getPrepareStatementCount()).isEqualTo(1);
+    }
+
+    @Test
+    void getById() {
+        Optional<Book> optionalActualBook = bookRepositoryJpa.getById(1L);
+        Book expectedBook = em.find(Book.class, 1L);
+        assertThat(optionalActualBook).isPresent().get()
+                .isEqualToComparingFieldByField(expectedBook);
+    }
+
+    @Test
+    void insert() {
+        Author author = new Author();
+        author.setName("name");
+        author.setSurname("surname");
+        Genre genre = new Genre();
+        genre.setName("name");
+
+        Book book = new Book();
+        book.setName("new");
+        book.setAuthor(author);
+        book.setGenre(genre);
+
+        Comment comment = new Comment();
+        comment.setText("good");
+        book.setComments(Collections.singletonList(comment));
+
+        Book newBook = bookRepositoryJpa.insertOrUpdate(book);
+        Book expectedBook = em.find(Book.class, newBook.getId());
+        Assertions.assertThat(expectedBook).isNotNull()
+                .matches(b -> b.getId() == newBook.getId())
+                .matches(b -> b.getName().equals(newBook.getName()))
+                .matches(b -> b.getAuthor().equals(newBook.getAuthor()))
+                .matches(b -> b.getGenre().equals(newBook.getGenre()))
+                .matches(b -> b.getComments() != null && b.getComments().size() > 0 );
+    }
+
+    @Test
+    void remove() {
+        Book firstBook = em.find(Book.class, 1L);
+        assertThat(firstBook).isNotNull();
+        em.detach(firstBook);
+
+        bookRepositoryJpa.remove(1);
+        Book deletedBook = em.find(Book.class, 1L);
+
+        assertThat(deletedBook).isNull();
+    }
+}

--- a/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/CommentRepositoryJpaTest.java
+++ b/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/CommentRepositoryJpaTest.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Import;
 import ru.otus.hw06jpql.domain.Book;
 import ru.otus.hw06jpql.domain.Comment;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,6 +47,15 @@ class CommentRepositoryJpaTest {
         Comment expectedComment = em.find(Comment.class, 1L);
         assertThat(optionalActualComment).isPresent().get()
                 .isEqualToComparingFieldByField(expectedComment);
+    }
+
+    @Test
+    void getCommentsByBookId() {
+        List<Comment> comments = commentRepository.getCommentsByBookId(1L);
+        assertEquals(3, comments.size());
+        assertThat(comments).matches(c -> c.get(0).getText().equals("good"))
+                .matches(c -> c.get(1).getText().equals("bad"))
+                .matches(c -> c.get(2).getText().equals("not bad"));
     }
 
     @Test

--- a/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/CommentRepositoryJpaTest.java
+++ b/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/CommentRepositoryJpaTest.java
@@ -1,0 +1,62 @@
+package ru.otus.hw06jpql.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import ru.otus.hw06jpql.domain.Book;
+import ru.otus.hw06jpql.domain.Comment;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import({CommentRepositoryJpa.class})
+class CommentRepositoryJpaTest {
+
+    @Autowired
+    private CommentRepositoryJpa commentRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void insertOrUpdate() {
+        Book book = new Book();
+        book.setId(1);
+        Comment comment = new Comment();
+        comment.setBook(book);
+        comment.setText("2222");
+
+        Comment newComment = commentRepository.insertOrUpdate(comment);
+        Comment expectedComment = em.find(Comment.class, newComment.getId());
+        Assertions.assertThat(expectedComment).isNotNull()
+                .matches(c -> c.getId() == newComment.getId())
+                .matches(c -> c.getBook().getId() == newComment.getBook().getId())
+                .matches(c -> c.getText().equals(newComment.getText()));
+    }
+
+    @Test
+    void getById() {
+        Optional<Comment> optionalActualComment = commentRepository.getById(1L);
+        Comment expectedComment = em.find(Comment.class, 1L);
+        assertThat(optionalActualComment).isPresent().get()
+                .isEqualToComparingFieldByField(expectedComment);
+    }
+
+    @Test
+    void remove() {
+        Comment firstComment = em.find(Comment.class, 1L);
+        assertThat(firstComment).isNotNull();
+        em.detach(firstComment);
+
+        commentRepository.remove(1);
+        Comment deletedComment = em.find(Comment.class, 1L);
+
+        assertThat(deletedComment).isNull();
+    }
+}

--- a/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/CommentRepositoryJpaTest.java
+++ b/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/CommentRepositoryJpaTest.java
@@ -50,15 +50,6 @@ class CommentRepositoryJpaTest {
     }
 
     @Test
-    void getCommentsByBookId() {
-        List<Comment> comments = commentRepository.getCommentsByBookId(1L);
-        assertEquals(3, comments.size());
-        assertThat(comments).matches(c -> c.get(0).getText().equals("good"))
-                .matches(c -> c.get(1).getText().equals("bad"))
-                .matches(c -> c.get(2).getText().equals("not bad"));
-    }
-
-    @Test
     void remove() {
         Comment firstComment = em.find(Comment.class, 1L);
         assertThat(firstComment).isNotNull();

--- a/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/GenreRepositoryJpaTest.java
+++ b/hw-06-jpql/src/test/java/ru/otus/hw06jpql/repository/GenreRepositoryJpaTest.java
@@ -1,0 +1,43 @@
+package ru.otus.hw06jpql.repository;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import ru.otus.hw06jpql.domain.Genre;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(GenreRepositoryJpa.class)
+class GenreRepositoryJpaTest {
+
+    @Autowired
+    private GenreRepositoryJpa genreRepositoryJpa;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void insert() {
+        Genre genre = new Genre();
+        genre.setName("name");
+        Genre newGenre = genreRepositoryJpa.insertOrUpdate(genre);
+        Genre expectedGenre = em.find(Genre.class, newGenre.getId());
+        Assertions.assertThat(expectedGenre).isNotNull()
+                .matches(g -> g.getId() == newGenre.getId())
+                .matches(g -> g.getName().equals(newGenre.getName()));
+    }
+
+    @Test
+    void getById() {
+        Optional<Genre> optionalActualGenre = genreRepositoryJpa.getById(1L);
+        Genre expectedGenre = em.find(Genre.class, 1L);
+        assertThat(optionalActualGenre).isPresent().get()
+                .isEqualToComparingFieldByField(expectedGenre);
+    }
+}

--- a/hw-06-jpql/src/test/java/ru/otus/hw06jpql/service/BookShellTest.java
+++ b/hw-06-jpql/src/test/java/ru/otus/hw06jpql/service/BookShellTest.java
@@ -1,0 +1,44 @@
+package ru.otus.hw06jpql.service;
+
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import ru.otus.hw06jpql.domain.Book;
+import ru.otus.hw06jpql.domain.Comment;
+import ru.otus.hw06jpql.repository.AuthorRepositoryJpa;
+import ru.otus.hw06jpql.repository.BookRepositoryJpa;
+import ru.otus.hw06jpql.repository.GenreRepositoryJpa;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import({BookRepositoryJpa.class, AuthorRepositoryJpa.class, GenreRepositoryJpa.class, BookShell.class})
+class BookShellTest {
+
+    @Autowired
+    private BookRepositoryJpa bookRepositoryJpa;
+
+    @Autowired
+    private BookShell bookShell;
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Test
+    void getCommentsByBook() {
+        SessionFactory sessionFactory = em.getEntityManager().getEntityManagerFactory()
+                .unwrap(SessionFactory.class);
+        sessionFactory.getStatistics().setStatisticsEnabled(true);
+        Book book = bookRepositoryJpa.getById(1L).get();
+        assertThat(sessionFactory.getStatistics().getPrepareStatementCount()).isEqualTo(1);
+        List<Comment> comments = bookShell.getCommentsByBook(book);
+        assertEquals(3, comments.size());
+        assertThat(sessionFactory.getStatistics().getPrepareStatementCount()).isEqualTo(2);
+    }
+}

--- a/hw-06-jpql/src/test/resources/application.yml
+++ b/hw-06-jpql/src/test/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    initialization-mode: always
+    data: testData.sql
+  shell:
+    interactive:
+      enabled: false
+
+  jpa:
+    generate-ddl: false
+    hibernate:
+      ddl-auto: none
+    show-sql: false
+
+logging:
+  level:
+    ROOT: ERROR

--- a/hw-06-jpql/src/test/resources/testData.sql
+++ b/hw-06-jpql/src/test/resources/testData.sql
@@ -1,0 +1,10 @@
+insert into author (`name`, `surname`) values ('Рей', 'Брэдбери');
+insert into author (`name`, `surname`) values ('Джордж', 'Оруэлл');
+insert into genre (`name`) values ('Антиутопия');
+insert into genre (`name`) values ('Роман');
+insert into book (`name`,`author_id`,`genre_id`) values ('Вино из одуванчиков', 1,2);
+insert into book (`name`,`author_id`,`genre_id`) values ('1984',2,1);
+insert into comment (`text`,`book_id`) values ('good',1);
+insert into comment (`text`,`book_id`) values ('bad',1);
+insert into comment (`text`,`book_id`) values ('not bad',1);
+insert into comment (`text`,`book_id`) values ('not bad',2);

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>hw03-spring-boot</module>
         <module>hw04-spring-shell</module>
         <module>hw-05-jdbc</module>
+        <module>hw-06-jpql</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Переписать приложение для хранения книг на ORM
Цель: Цель: полноценно работать с JPA + Hibernate для подключения к реляционным БД посредством ORM-фреймворка
Результат: Высокоуровневое приложение с JPA-маппингом сущностей
Домашнее задание выполняется переписыванием предыдущего на JPA.

Требования:
1. Использовать JPA, Hibernate только в качестве JPA-провайдера.
2. Для решения проблемы N+1 можно использовать специфические для Hibernate аннотации @Fetch и @BatchSize.
3. Добавить сущность "комментария к книге", реализовать CRUD для новой сущности.
4. Покрыть репозитории тестами, используя H2 базу данных и соответствующий H2 Hibernate-диалект для тестов.
5. Не забудьте отключить DDL через Hibernate
6. @Transactional рекомендуется ставить только на методы сервиса.